### PR TITLE
Update team disagreement example to match actual comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,9 +204,9 @@ Example:
 >## :question: Issue type
 >### Team says:
 >
->Team chose `DocumentationBug`.
+>Team chose [`type.DocumentationBug`].
 >
->Originally `FunctionalityBug`.
+>Originally [`type.FunctionalityBug`].
 >
 >### Tester says:
 >I think it a functionality bug.

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Example:
 ># Items for the Tester to Verify
 >## :question: Issue response
 >
->Team chose `Rejected`.
+>Team chose [`response.Rejected`].
 >
 >- [ ] I disagree
 >
@@ -128,9 +128,9 @@ Example:
 >-------------------
 >## :question: Issue severity
 >
->Team chose `Low`.
+>Team chose [`severity.Low`].
 >
->Originally `High`.
+>Originally [`severity.High`].
 >
 >- [ ] I disagree
 >
@@ -140,9 +140,9 @@ Example:
 >-------------------
 >## :question: Issue type
 >
->Team chose `DocumentationBug`.
+>Team chose [`type.DocumentationBug`].
 >
->Originally `FunctionalityBug`.
+>Originally [`type.FunctionalityBug`].
 >
 >- [ ] I disagree
 >
@@ -165,9 +165,9 @@ Update the comment. Example:
 
 >## :question: Issue type
 >
->Team chose `DocumentationBug`.
+>Team chose [`type.DocumentationBug`].
 >
->Originally `FunctionalityBug`.
+>Originally [`type.FunctionalityBug`].
 >
 >- [x] I disagree
 >


### PR DESCRIPTION
### Summary:
Similar to https://github.com/CATcher-org/catcher-org.github.io/pull/34, so refer to that for more details.
Let's update this repo to match the docs too.

### Changes Made:
* Update disagreement example to format that is actually being used

### Proposed Commit Message:
```
The disagreement examples in this template repo is not the same as what
is actually being used, and what is actually being parsed by CATcher

Let's update the README to match what's in the actual comments.
```
